### PR TITLE
fix: regionPicker2,cascader component options did not make a safe reaper

### DIFF
--- a/src/exts/RegionPicker2/index.js
+++ b/src/exts/RegionPicker2/index.js
@@ -220,7 +220,7 @@ class RegionPicker2 extends Component {
         className={className}
         style={style}
         placeholder={placeholder}
-        options={options}
+        options={options || []}
         value={internalVal}
         loadData={this._retrieveData}
         onChange={this._onSelectChange}


### PR DESCRIPTION
RegionPicker2 在使用Cascader组件时，options如果为null, 在Cascader的options.length报错：
TypeError: Cannot read property 'length' of null

导致我们的文档不能正常查阅：
https://dfocusfe.github.io/antd-extensions/#/antd-extensions/api/regionpicker2